### PR TITLE
docs: debugging: modify props to gets bootloop logs via adb

### DIFF
--- a/wiki/Debugging.md
+++ b/wiki/Debugging.md
@@ -69,6 +69,12 @@
     sed -i 's/^persist\.sys\.usb\.config=.*/persist.sys.usb.config=adb/' build.prop
     ```
 
+6) Now copy the modified `build.prop` to /system by running:
+    
+    ```
+    adb push build.prop /system_root/system/
+    ```
+
 ### This too might work
 1) Reboot into TWRP.
 2) `adb pull /data/boot_lc_main.txt` (if it exists).

--- a/wiki/Debugging.md
+++ b/wiki/Debugging.md
@@ -19,7 +19,7 @@
 
     while on bootsplash
 
-### Stuck at bootanimation/splash (or need regular logs but ADB is dead)
+### Override ADB authentication to capture logs during boot
 1) Reboot into recovery.
 2) Mount `system` in recovery.
 3) Connect to PC.
@@ -31,51 +31,34 @@
 
 5) Use a text editor to change the following props in build.prop 
 
-    `ro.adb.secure=0`
+    ```ro.adb.secure=0```
     
-    `ro.debuggable=1`
+    ```ro.debuggable=1```
     
-    `ro.secure=0`
+    ```ro.secure=0```
     
-    `persist.service.adb.enable=1`
+    ```persist.service.adb.enable=1```
     
-    `persist.service.debuggable=1`
+    ```persist.service.debuggable=1```
     
-    `persist.sys.usb.config=adb`
+    ```persist.sys.usb.config=adb```
 
     or if `GNU sed` is available on your system:
 
     ```
     sed -i 's/^ro\.adb\.secure=.*/ro.adb.secure=0/' build.prop
-    ```
-    
-    ```
     sed -i 's/^ro\.debuggable=.*/ro.debuggable=1/' build.prop
-    ```
-    
-    ```
     sed -i 's/^ro\.secure=.*/ro.secure=0/' build.prop
-    ```
-    
-    ```
     sed -i 's/^persist\.service\.adb\.enable=.*/persist.service.adb.enable=1/' build.prop
-    ```
-    
-    ```
     sed -i 's/^persist\.service\.debuggable=.*/persist.service.debuggable=1/' build.prop
-    ```
-    
-    ```
     sed -i 's/^persist\.sys\.usb\.config=.*/persist.sys.usb.config=adb/' build.prop
     ```
 
 6) Now copy the modified `build.prop` to /system by running:
     
-    ```
-    adb push build.prop /system_root/system/
-    ```
+    ```adb push build.prop /system_root/system/```
 
-### This too might work
+### Pull `/data/boot_lc_main.txt` 
 1) Reboot into TWRP.
 2) `adb pull /data/boot_lc_main.txt` (if it exists).
 

--- a/wiki/Debugging.md
+++ b/wiki/Debugging.md
@@ -20,6 +20,56 @@
     while on bootsplash
 
 ### Stuck at bootanimation/splash (or need regular logs but ADB is dead)
+1) Reboot into recovery.
+2) Mount `system` in recovery.
+3) Connect to PC.
+4) Run:
+
+    ```adb shell mount -o rw,remount /system_root```
+
+    ```adb pull /system_root/system/build.prop```
+
+5) Use a text editor to change the following props in build.prop 
+
+    `ro.adb.secure=0`
+    
+    `ro.debuggable=1`
+    
+    `ro.secure=0`
+    
+    `persist.service.adb.enable=1`
+    
+    `persist.service.debuggable=1`
+    
+    `persist.sys.usb.config=adb`
+
+    or if `GNU sed` is available on your system:
+
+    ```
+    sed -i 's/^ro\.adb\.secure=.*/ro.adb.secure=0/' build.prop
+    ```
+    
+    ```
+    sed -i 's/^ro\.debuggable=.*/ro.debuggable=1/' build.prop
+    ```
+    
+    ```
+    sed -i 's/^ro\.secure=.*/ro.secure=0/' build.prop
+    ```
+    
+    ```
+    sed -i 's/^persist\.service\.adb\.enable=.*/persist.service.adb.enable=1/' build.prop
+    ```
+    
+    ```
+    sed -i 's/^persist\.service\.debuggable=.*/persist.service.debuggable=1/' build.prop
+    ```
+    
+    ```
+    sed -i 's/^persist\.sys\.usb\.config=.*/persist.sys.usb.config=adb/' build.prop
+    ```
+
+### This too might work
 1) Reboot into TWRP.
 2) `adb pull /data/boot_lc_main.txt` (if it exists).
 


### PR DESCRIPTION
* Check for spelling misfakes.
* Suggest an alt. heading to "[This too might work](https://github.com/omansh-krishn/opendroid-docs/blob/master/wiki/Debugging.md?plain=1#L72)".